### PR TITLE
fix: type to enum and refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,6 +74,7 @@ resharper_object_creation_when_type_not_evident = target_typed
 resharper_parentheses_redundancy_style = remove
 resharper_trailing_comma_in_multiline_lists = true
 resharper_use_indent_from_vs = false
+resharper_wrap_object_and_collection_initializer_style = chop_always
 resharper_xmldoc_indent_child_elements = RemoveIndent
 resharper_xmldoc_indent_text = RemoveIndent
 
@@ -90,7 +91,6 @@ resharper_mvc_area_not_resolved_highlighting = warning
 resharper_mvc_controller_not_resolved_highlighting = warning
 resharper_mvc_masterpage_not_resolved_highlighting = warning
 resharper_mvc_partial_view_not_resolved_highlighting = warning
-resharper_wrap_object_and_collection_initializer_style = chop_always
 resharper_mvc_template_not_resolved_highlighting = warning
 resharper_mvc_view_component_not_resolved_highlighting = warning
 resharper_mvc_view_component_view_not_resolved_highlighting = warning

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -63,6 +63,7 @@ jobs:
                     /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
                     /d:sonar.host.url="https://sonarcloud.io"
                     /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+                    /d:sonar.coverage.exclusions="**/Models/**/*"
             -   name: Build the project
                 shell: bash
                 run: |

--- a/SURFSharekit.Net.Tests/SURFSharekitApiClientTests.cs
+++ b/SURFSharekit.Net.Tests/SURFSharekitApiClientTests.cs
@@ -39,7 +39,7 @@ public class SURFSharekitApiClientTests
     /// <summary>
     /// Given a valid <see cref="SURFSharekitApiClient" />,
     /// When GetRepoItemById is called,
-    /// Then it should return the <see cref="SURFSharekitRepoItem" /> specified by that id.
+    /// Then it should return the <see cref="Models.SURFSharekitRepoItem" /> specified by that id.
     /// </summary>
     [Fact]
     public async Task GetRepoItemById_ReturnsRepoItem()
@@ -203,10 +203,10 @@ public class SURFSharekitApiClientTests
         Assert.NotNull(item);
         Assert.Equal("dummy-id", item.Id);
         Assert.Equal("repoItem", item.Type);
-        Assert.NotNull(item.SURFSharekitAttributes);
-        Assert.Equal("Test Title", item.SURFSharekitAttributes.Title);
-        Assert.NotEmpty(item.SURFSharekitAttributes.Authors);
-        Assert.Equal("John Doe", item.SURFSharekitAttributes.Authors[0].SURFSharekitPerson?.Name);
+        Assert.NotNull(item.Attributes);
+        Assert.Equal("Test Title", item.Attributes.Title);
+        Assert.NotEmpty(item.Attributes.Authors);
+        Assert.Equal("John Doe", item.Attributes.Authors[0].Person?.Name);
     }
 
     /// <summary>
@@ -395,14 +395,14 @@ public class SURFSharekitApiClientTests
         Assert.Equal("7c90e92e-712a-423f-9d62-a15d38ef28ed", firstRepoItem.Id);
         Assert.Equal("repoItem", firstRepoItem.Type);
 
-        Assert.NotNull(firstRepoItem.SURFSharekitAttributes);
-        Assert.Equal("10.80467/8b0f8e7a-4ac8-4401-81ff-59cfec949f48", firstRepoItem.SURFSharekitAttributes.Doi);
+        Assert.NotNull(firstRepoItem.Attributes);
+        Assert.Equal("10.80467/8b0f8e7a-4ac8-4401-81ff-59cfec949f48", firstRepoItem.Attributes.Doi);
 
-        Assert.NotNull(firstRepoItem.SURFSharekitAttributes.SURFSharekitVocabularies);
+        Assert.NotNull(firstRepoItem.Attributes.Vocabularies);
         Assert.Equal("http://purl.edustandaard.nl/concept/6d78d67c-9d42-4f57-9fa2-b24aabbcf892",
-            firstRepoItem.SURFSharekitAttributes.SURFSharekitVocabularies.VocabularyDas[0].Source);
+            firstRepoItem.Attributes.Vocabularies.VocabularyDas[0].Source);
 
-        Assert.NotNull(firstRepoItem.SURFSharekitAttributes.SURFSharekitOwner);
-        Assert.Equal("6949c6f2-517c-4c3e-881f-3d712e0b0640", firstRepoItem.SURFSharekitAttributes.SURFSharekitOwner.Id);
+        Assert.NotNull(firstRepoItem.Attributes.Owner);
+        Assert.Equal("6949c6f2-517c-4c3e-881f-3d712e0b0640", firstRepoItem.Attributes.Owner.Id);
     }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitAttributes.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitAttributes.cs
@@ -1,90 +1,123 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitAttributes
 {
-    public class SURFSharekitAttributes
-    {
-        [JsonPropertyName("owner")] public SURFSharekitOwner? Owner { get; set; }
+    [JsonPropertyName("owner")]
+    public SURFSharekitOwner? Owner { get; set; }
 
-        [JsonPropertyName("mboDomain")] public List<string> MboDomain { get; set; } = [];
+    [JsonPropertyName("mboDomain")]
+    public List<string> MboDomain { get; set; } = [];
 
-        [JsonPropertyName("mboDiscipline")] public List<string> MboDiscipline { get; set; } = [];
+    [JsonPropertyName("mboDiscipline")]
+    public List<string> MboDiscipline { get; set; } = [];
 
-        [JsonPropertyName("typicalAgeRange")] public SURFSharekitTypicalAgeRange? TypicalAgeRange { get; set; }
+    [JsonPropertyName("typicalAgeRange")]
+    public SURFSharekitTypicalAgeRange? TypicalAgeRange { get; set; }
 
-        [JsonPropertyName("cost")] public SURFSharekitCost? Cost { get; set; }
+    [JsonPropertyName("cost")]
+    public SURFSharekitCost? Cost { get; set; }
 
-        [JsonPropertyName("urn:nbn")] public string? UrnNbn { get; set; }
+    [JsonPropertyName("urn:nbn")]
+    public string? UrnNbn { get; set; }
 
-        [JsonPropertyName("modifiedAt")] public DateTime? ModifiedAt { get; set; }
+    [JsonPropertyName("modifiedAt")]
+    public DateTime? ModifiedAt { get; set; }
 
-        [JsonPropertyName("title")] public string? Title { get; set; }
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
 
-        [JsonPropertyName("subtitle")] public string? Subtitle { get; set; }
+    [JsonPropertyName("subtitle")]
+    public string? Subtitle { get; set; }
 
-        [JsonPropertyName("publishers")] public List<string> Publishers { get; set; } = [];
+    [JsonPropertyName("publishers")]
+    public List<string> Publishers { get; set; } = [];
 
-        [JsonPropertyName("publishedAt")] public string? PublishedAt { get; set; }
+    [JsonPropertyName("publishedAt")]
+    public string? PublishedAt { get; set; }
 
-        [JsonPropertyName("place")] public string? Place { get; set; }
+    [JsonPropertyName("place")]
+    public string? Place { get; set; }
 
-        [JsonPropertyName("abstract")] public string? Abstract { get; set; }
+    [JsonPropertyName("abstract")]
+    public string? Abstract { get; set; }
 
-        [JsonPropertyName("keywords")] public List<string> Keywords { get; set; } = [];
+    [JsonPropertyName("keywords")]
+    public List<string> Keywords { get; set; } = [];
 
-        [JsonPropertyName("numOfPages")] public string? NumOfPages { get; set; }
+    [JsonPropertyName("numOfPages")]
+    public string? NumOfPages { get; set; }
 
-        [JsonPropertyName("links")] public List<SURFSharekitLink> Links { get; set; } = [];
+    [JsonPropertyName("links")]
+    public List<SURFSharekitLink> Links { get; set; } = [];
 
-        [JsonPropertyName("authors")] public List<SURFSharekitAuthor> Authors { get; set; } = [];
+    [JsonPropertyName("authors")]
+    public List<SURFSharekitAuthor> Authors { get; set; } = [];
 
-        [JsonPropertyName("files")] public List<SURFSharekitFile> Files { get; set; } = [];
+    [JsonPropertyName("files")]
+    public List<SURFSharekitFile> Files { get; set; } = [];
 
-        [JsonPropertyName("institutes")] public List<SURFSharekitInstitute> Institutes { get; set; } = [];
+    [JsonPropertyName("institutes")]
+    public List<SURFSharekitInstitute> Institutes { get; set; } = [];
 
-        [JsonPropertyName("language")] public string? Language { get; set; }
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
 
-        [JsonPropertyName("themesResearchObject")]
-        public string? ThemesResearchObject { get; set; }
+    [JsonPropertyName("themesResearchObject")]
+    public string? ThemesResearchObject { get; set; }
 
-        [JsonPropertyName("termsOfUse")] public string? TermsOfUse { get; set; }
+    [JsonPropertyName("termsOfUse")]
+    public string? TermsOfUse { get; set; }
 
-        [JsonPropertyName("educationalLevels")]
-        public List<SURFSharekitEducationalLevel> EducationalLevels { get; set; } = [];
+    [JsonPropertyName("educationalLevels")]
+    public List<SURFSharekitEducationalLevel> EducationalLevels { get; set; } = [];
 
-        [JsonPropertyName("typeResearchObject")]
-        public string? TypeResearchObject { get; set; }
+    [JsonPropertyName("typeResearchObject")]
+    public string? TypeResearchObject { get; set; }
 
-        [JsonPropertyName("typesLearningMaterial")]
-        public List<string> TypesLearningMaterial { get; set; } = [];
+    [JsonPropertyName("typesLearningMaterial")]
+    public List<string> TypesLearningMaterial { get; set; } = [];
 
-        [JsonPropertyName("themesLearningMaterial")]
-        public List<string> ThemesLearningMaterial { get; set; } = [];
+    [JsonPropertyName("themesLearningMaterial")]
+    public List<string> ThemesLearningMaterial { get; set; } = [];
 
-        [JsonPropertyName("hasParts")] public List<string> HasParts { get; set; } = [];
+    [JsonPropertyName("hasParts")]
+    public List<string> HasParts { get; set; } = [];
 
-        [JsonPropertyName("partOf")] public List<string> PartOf { get; set; } = [];
+    [JsonPropertyName("partOf")]
+    public List<string> PartOf { get; set; } = [];
 
-        [JsonPropertyName("technicalFormat")] public string? TechnicalFormat { get; set; }
+    [JsonPropertyName("technicalFormat")]
+    public string? TechnicalFormat { get; set; }
 
-        [JsonPropertyName("vocabularies")] public SURFSharekitVocabularies? Vocabularies { get; set; }
+    [JsonPropertyName("vocabularies")]
+    public SURFSharekitVocabularies? Vocabularies { get; set; }
 
-        [JsonPropertyName("aggregationlevel")] public string? Aggregationlevel { get; set; }
+    [JsonPropertyName("aggregationlevel")]
+    public string? Aggregationlevel { get; set; }
 
-        [JsonPropertyName("intendedUser")] public string? IntendedUser { get; set; }
+    [JsonPropertyName("intendedUser")]
+    public string? IntendedUser { get; set; }
 
-        [JsonPropertyName("raid")] public string? Raid { get; set; }
+    [JsonPropertyName("raid")]
+    public string? Raid { get; set; }
 
-        [JsonPropertyName("siaFileNum")] public string? SiaFileNum { get; set; }
+    [JsonPropertyName("siaFileNum")]
+    public string? SiaFileNum { get; set; }
 
-        [JsonPropertyName("doi")] public string? Doi { get; set; }
+    [JsonPropertyName("doi")]
+    public string? Doi { get; set; }
 
-        [JsonPropertyName("handle")] public string? Handle { get; set; }
+    [JsonPropertyName("handle")]
+    public string? Handle { get; set; }
 
-        [JsonPropertyName("availability")] public string? Availability { get; set; }
+    [JsonPropertyName("availability")]
+    public string? Availability { get; set; }
 
-        [JsonPropertyName("publishedIn")] public SURFSharekitPublishedIn? PublishedIn { get; set; }
+    [JsonPropertyName("publishedIn")]
+    public SURFSharekitPublishedIn? PublishedIn { get; set; }
 
-        [JsonPropertyName("conference")] public string? Conference { get; set; }
-    }
+    [JsonPropertyName("conference")]
+    public string? Conference { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitAttributes.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitAttributes.cs
@@ -1,119 +1,90 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitAttributes
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("owner")]
-    public SURFSharekitOwner? SURFSharekitOwner { get; set; }
+    public class SURFSharekitAttributes
+    {
+        [JsonPropertyName("owner")] public SURFSharekitOwner? Owner { get; set; }
 
-    [JsonPropertyName("consortium")]
-    public string? Consortium { get; set; }
+        [JsonPropertyName("mboDomain")] public List<string> MboDomain { get; set; } = [];
 
-    [JsonPropertyName("typicalAgeRange")]
-    public string? TypicalAgeRange { get; set; }
+        [JsonPropertyName("mboDiscipline")] public List<string> MboDiscipline { get; set; } = [];
 
-    [JsonPropertyName("cost")]
-    public SURFSharekitCost? SURFSharekitCost { get; set; }
+        [JsonPropertyName("typicalAgeRange")] public SURFSharekitTypicalAgeRange? TypicalAgeRange { get; set; }
 
-    [JsonPropertyName("urn:nbn")]
-    public string? UrnNbn { get; set; }
+        [JsonPropertyName("cost")] public SURFSharekitCost? Cost { get; set; }
 
-    [JsonPropertyName("modifiedAt")]
-    public DateTime? ModifiedAt { get; set; }
+        [JsonPropertyName("urn:nbn")] public string? UrnNbn { get; set; }
 
-    [JsonPropertyName("title")]
-    public string? Title { get; set; }
+        [JsonPropertyName("modifiedAt")] public DateTime? ModifiedAt { get; set; }
 
-    [JsonPropertyName("subtitle")]
-    public string? Subtitle { get; set; }
+        [JsonPropertyName("title")] public string? Title { get; set; }
 
-    [JsonPropertyName("publishers")]
-    public List<string> Publishers { get; set; } = [];
+        [JsonPropertyName("subtitle")] public string? Subtitle { get; set; }
 
-    [JsonPropertyName("publishedAt")]
-    public string? PublishedAt { get; set; }
+        [JsonPropertyName("publishers")] public List<string> Publishers { get; set; } = [];
 
-    [JsonPropertyName("place")]
-    public string? Place { get; set; }
+        [JsonPropertyName("publishedAt")] public string? PublishedAt { get; set; }
 
-    [JsonPropertyName("abstract")]
-    public string? Abstract { get; set; }
+        [JsonPropertyName("place")] public string? Place { get; set; }
 
-    [JsonPropertyName("keywords")]
-    public List<string> Keywords { get; set; } = [];
+        [JsonPropertyName("abstract")] public string? Abstract { get; set; }
 
-    [JsonPropertyName("numOfPages")]
-    public int? NumOfPages { get; set; }
+        [JsonPropertyName("keywords")] public List<string> Keywords { get; set; } = [];
 
-    [JsonPropertyName("links")]
-    public List<SURFSharekitLink> Links { get; set; } = [];
+        [JsonPropertyName("numOfPages")] public string? NumOfPages { get; set; }
 
-    [JsonPropertyName("authors")]
-    public List<SURFSharekitAuthor> Authors { get; set; } = [];
+        [JsonPropertyName("links")] public List<SURFSharekitLink> Links { get; set; } = [];
 
-    [JsonPropertyName("files")]
-    public List<SURFSharekitFile> Files { get; set; } = [];
+        [JsonPropertyName("authors")] public List<SURFSharekitAuthor> Authors { get; set; } = [];
 
-    [JsonPropertyName("institutes")]
-    public List<SURFSharekitInstitute> Institutes { get; set; } = [];
+        [JsonPropertyName("files")] public List<SURFSharekitFile> Files { get; set; } = [];
 
-    [JsonPropertyName("language")]
-    public string? Language { get; set; }
+        [JsonPropertyName("institutes")] public List<SURFSharekitInstitute> Institutes { get; set; } = [];
 
-    [JsonPropertyName("themesResearchObject")]
-    public string? ThemesResearchObject { get; set; }
+        [JsonPropertyName("language")] public string? Language { get; set; }
 
-    [JsonPropertyName("termsOfUse")]
-    public string? TermsOfUse { get; set; }
+        [JsonPropertyName("themesResearchObject")]
+        public string? ThemesResearchObject { get; set; }
 
-    [JsonPropertyName("educationalLevels")]
-    public List<SURFSharekitEducationalLevel> EducationalLevels { get; set; } = [];
+        [JsonPropertyName("termsOfUse")] public string? TermsOfUse { get; set; }
 
-    [JsonPropertyName("typeResearchObject")]
-    public string? TypeResearchObject { get; set; }
+        [JsonPropertyName("educationalLevels")]
+        public List<SURFSharekitEducationalLevel> EducationalLevels { get; set; } = [];
 
-    [JsonPropertyName("typesLearningMaterial")]
-    public List<string> TypesLearningMaterial { get; set; } = [];
+        [JsonPropertyName("typeResearchObject")]
+        public string? TypeResearchObject { get; set; }
 
-    [JsonPropertyName("themesLearningMaterial")]
-    public List<string> ThemesLearningMaterial { get; set; } = [];
+        [JsonPropertyName("typesLearningMaterial")]
+        public List<string> TypesLearningMaterial { get; set; } = [];
 
-    [JsonPropertyName("hasParts")]
-    public List<string> HasParts { get; set; } = [];
+        [JsonPropertyName("themesLearningMaterial")]
+        public List<string> ThemesLearningMaterial { get; set; } = [];
 
-    [JsonPropertyName("partOf")]
-    public List<string> PartOf { get; set; } = [];
+        [JsonPropertyName("hasParts")] public List<string> HasParts { get; set; } = [];
 
-    [JsonPropertyName("technicalFormat")]
-    public string? TechnicalFormat { get; set; }
+        [JsonPropertyName("partOf")] public List<string> PartOf { get; set; } = [];
 
-    [JsonPropertyName("vocabularies")]
-    public SURFSharekitVocabularies? SURFSharekitVocabularies { get; set; }
+        [JsonPropertyName("technicalFormat")] public string? TechnicalFormat { get; set; }
 
-    [JsonPropertyName("aggregationlevel")]
-    public string? AggregationLevel { get; set; }
+        [JsonPropertyName("vocabularies")] public SURFSharekitVocabularies? Vocabularies { get; set; }
 
-    [JsonPropertyName("intendedUser")]
-    public string? IntendedUser { get; set; }
+        [JsonPropertyName("aggregationlevel")] public string? Aggregationlevel { get; set; }
 
-    [JsonPropertyName("doi")]
-    public string? Doi { get; set; }
+        [JsonPropertyName("intendedUser")] public string? IntendedUser { get; set; }
 
-    [JsonPropertyName("availability")]
-    public string? Availability { get; set; }
+        [JsonPropertyName("raid")] public string? Raid { get; set; }
 
-    [JsonPropertyName("handle")]
-    public string? Handle { get; set; }
+        [JsonPropertyName("siaFileNum")] public string? SiaFileNum { get; set; }
 
-    [JsonPropertyName("publishedIn")]
-    public SURFSharekitPublishedIn? SURFSharekitPublishedIn { get; set; }
+        [JsonPropertyName("doi")] public string? Doi { get; set; }
 
-    [JsonPropertyName("conference")]
-    public string? Conference { get; set; }
+        [JsonPropertyName("handle")] public string? Handle { get; set; }
+
+        [JsonPropertyName("availability")] public string? Availability { get; set; }
+
+        [JsonPropertyName("publishedIn")] public SURFSharekitPublishedIn? PublishedIn { get; set; }
+
+        [JsonPropertyName("conference")] public string? Conference { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitAuthor.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitAuthor.cs
@@ -1,15 +1,18 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitAuthor
 {
-    public class SURFSharekitAuthor
-    {
-        [JsonPropertyName("person")] public SURFSharekitPerson? Person { get; set; }
+    [JsonPropertyName("person")]
+    public SURFSharekitPerson? Person { get; set; }
 
-        [JsonPropertyName("role")] public string? Role { get; set; }
+    [JsonPropertyName("role")]
+    public string? Role { get; set; }
 
-        [JsonPropertyName("external")] public string? External { get; set; }
+    [JsonPropertyName("external")]
+    public string? External { get; set; }
 
-        [JsonPropertyName("alias")] public string? Alias { get; set; }
-    }
+    [JsonPropertyName("alias")]
+    public string? Alias { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitAuthor.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitAuthor.cs
@@ -1,17 +1,15 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitAuthor
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("person")]
-    public SURFSharekitPerson? SURFSharekitPerson { get; set; }
+    public class SURFSharekitAuthor
+    {
+        [JsonPropertyName("person")] public SURFSharekitPerson? Person { get; set; }
 
-    [JsonPropertyName("role")]
-    public string? Role { get; set; }
+        [JsonPropertyName("role")] public string? Role { get; set; }
+
+        [JsonPropertyName("external")] public string? External { get; set; }
+
+        [JsonPropertyName("alias")] public string? Alias { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitCost.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitCost.cs
@@ -1,11 +1,12 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
-{
-    public class SURFSharekitCost
-    {
-        [JsonPropertyName("source")] public string? Source { get; set; }
+namespace SURFSharekit.Net.Models;
 
-        [JsonPropertyName("value")] public string? Value { get; set; }
-    }
+public class SURFSharekitCost
+{
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitCost.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitCost.cs
@@ -1,17 +1,11 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitCost
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("source")]
-    public string? Source { get; set; }
+    public class SURFSharekitCost
+    {
+        [JsonPropertyName("source")] public string? Source { get; set; }
 
-    [JsonPropertyName("value")]
-    public string? Value { get; set; }
+        [JsonPropertyName("value")] public string? Value { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitEducationalLevel.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitEducationalLevel.cs
@@ -1,11 +1,12 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
-{
-    public class SURFSharekitEducationalLevel
-    {
-        [JsonPropertyName("source")] public string? Source { get; set; }
+namespace SURFSharekit.Net.Models;
 
-        [JsonPropertyName("value")] public string? Value { get; set; }
-    }
+public class SURFSharekitEducationalLevel
+{
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitEducationalLevel.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitEducationalLevel.cs
@@ -1,17 +1,11 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitEducationalLevel
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("source")]
-    public string? Source { get; set; }
+    public class SURFSharekitEducationalLevel
+    {
+        [JsonPropertyName("source")] public string? Source { get; set; }
 
-    [JsonPropertyName("value")]
-    public string? Value { get; set; }
+        [JsonPropertyName("value")] public string? Value { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitFile.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitFile.cs
@@ -1,21 +1,27 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitFile
 {
-    public class SURFSharekitFile
-    {
-        [JsonPropertyName("fileName")] public string? FileName { get; set; }
+    [JsonPropertyName("fileName")]
+    public string? FileName { get; set; }
 
-        [JsonPropertyName("accessRight")] public string? AccessRight { get; set; }
+    [JsonPropertyName("accessRight")]
+    public string? AccessRight { get; set; }
 
-        [JsonPropertyName("url")] public string? Url { get; set; }
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
 
-        [JsonPropertyName("resourceMimeType")] public string? ResourceMimeType { get; set; }
+    [JsonPropertyName("resourceMimeType")]
+    public string? ResourceMimeType { get; set; }
 
-        [JsonPropertyName("usageRight")] public string? UsageRight { get; set; }
+    [JsonPropertyName("usageRight")]
+    public string? UsageRight { get; set; }
 
-        [JsonPropertyName("important")] public string? Important { get; set; }
+    [JsonPropertyName("important")]
+    public string? Important { get; set; }
 
-        [JsonPropertyName("eTag")] public string? ETag { get; set; }
-    }
+    [JsonPropertyName("eTag")]
+    public string? ETag { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitFile.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitFile.cs
@@ -1,26 +1,21 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitFile
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("fileName")]
-    public string? FileName { get; set; }
+    public class SURFSharekitFile
+    {
+        [JsonPropertyName("fileName")] public string? FileName { get; set; }
 
-    [JsonPropertyName("accessRight")]
-    public string? AccessRight { get; set; }
+        [JsonPropertyName("accessRight")] public string? AccessRight { get; set; }
 
-    [JsonPropertyName("eTag")]
-    public string? ETag { get; set; }
+        [JsonPropertyName("url")] public string? Url { get; set; }
 
-    [JsonPropertyName("url")]
-    public string? Url { get; set; }
+        [JsonPropertyName("resourceMimeType")] public string? ResourceMimeType { get; set; }
 
-    [JsonPropertyName("resourceMimeType")]
-    public string? ResourceMimeType { get; set; }
+        [JsonPropertyName("usageRight")] public string? UsageRight { get; set; }
+
+        [JsonPropertyName("important")] public string? Important { get; set; }
+
+        [JsonPropertyName("eTag")] public string? ETag { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitInstitute.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitInstitute.cs
@@ -1,13 +1,15 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitInstitute
 {
-    public class SURFSharekitInstitute
-    {
-        [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 
-        [JsonPropertyName("type")] public string? Type { get; set; }
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
 
-        [JsonPropertyName("id")] public string? Id { get; set; }
-    }
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitInstitute.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitInstitute.cs
@@ -1,20 +1,13 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitInstitute
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
+    public class SURFSharekitInstitute
+    {
+        [JsonPropertyName("name")] public string? Name { get; set; }
 
-    [JsonPropertyName("type")]
-    public string? Type { get; set; }
+        [JsonPropertyName("type")] public string? Type { get; set; }
 
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
+        [JsonPropertyName("id")] public string? Id { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitLink.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitLink.cs
@@ -1,20 +1,15 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitLink
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("url")]
-    public string? Url { get; set; }
+    public class SURFSharekitLink
+    {
+        [JsonPropertyName("url")] public string? Url { get; set; }
 
-    [JsonPropertyName("accessRight")]
-    public string? AccessRight { get; set; }
+        [JsonPropertyName("accessRight")] public string? AccessRight { get; set; }
 
-    [JsonPropertyName("urlName")]
-    public string? UrlName { get; set; }
+        [JsonPropertyName("urlName")] public string? UrlName { get; set; }
+
+        [JsonPropertyName("important")] public string? Important { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitLink.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitLink.cs
@@ -1,15 +1,18 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitLink
 {
-    public class SURFSharekitLink
-    {
-        [JsonPropertyName("url")] public string? Url { get; set; }
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
 
-        [JsonPropertyName("accessRight")] public string? AccessRight { get; set; }
+    [JsonPropertyName("accessRight")]
+    public string? AccessRight { get; set; }
 
-        [JsonPropertyName("urlName")] public string? UrlName { get; set; }
+    [JsonPropertyName("urlName")]
+    public string? UrlName { get; set; }
 
-        [JsonPropertyName("important")] public string? Important { get; set; }
-    }
+    [JsonPropertyName("important")]
+    public string? Important { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitMeta.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitMeta.cs
@@ -1,14 +1,9 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitMeta
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("totalCount")]
-    public int? TotalCount { get; set; }
+    public class SURFSharekitMeta
+    {
+        [JsonPropertyName("totalCount")] public int? TotalCount { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitMeta.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitMeta.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitMeta
 {
-    public class SURFSharekitMeta
-    {
-        [JsonPropertyName("totalCount")] public int? TotalCount { get; set; }
-    }
+    [JsonPropertyName("totalCount")]
+    public int? TotalCount { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitOwner.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitOwner.cs
@@ -1,20 +1,13 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitOwner
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public class SURFSharekitOwner
+    {
+        [JsonPropertyName("id")] public string? Id { get; set; }
 
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
 
-    [JsonPropertyName("type")]
-    public string? Type { get; set; }
+        [JsonPropertyName("type")] public string? Type { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitOwner.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitOwner.cs
@@ -1,13 +1,15 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitOwner
 {
-    public class SURFSharekitOwner
-    {
-        [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
 
-        [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 
-        [JsonPropertyName("type")] public string? Type { get; set; }
-    }
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitPerson.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitPerson.cs
@@ -1,29 +1,19 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitPerson
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public class SURFSharekitPerson
+    {
+        [JsonPropertyName("id")] public string? Id { get; set; }
 
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
 
-    [JsonPropertyName("email")]
-    public string? Email { get; set; }
+        [JsonPropertyName("email")] public string? Email { get; set; }
 
-    [JsonPropertyName("dai")]
-    public string? Dai { get; set; }
+        [JsonPropertyName("dai")] public string? Dai { get; set; }
 
-    [JsonPropertyName("orcid")]
-    public string? Orcid { get; set; }
+        [JsonPropertyName("orcid")] public string? Orcid { get; set; }
 
-    [JsonPropertyName("isni")]
-    public string? Isni { get; set; }
+        [JsonPropertyName("isni")] public string? Isni { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitPerson.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitPerson.cs
@@ -1,19 +1,24 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitPerson
 {
-    public class SURFSharekitPerson
-    {
-        [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
 
-        [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 
-        [JsonPropertyName("email")] public string? Email { get; set; }
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
 
-        [JsonPropertyName("dai")] public string? Dai { get; set; }
+    [JsonPropertyName("dai")]
+    public string? Dai { get; set; }
 
-        [JsonPropertyName("orcid")] public string? Orcid { get; set; }
+    [JsonPropertyName("orcid")]
+    public string? Orcid { get; set; }
 
-        [JsonPropertyName("isni")] public string? Isni { get; set; }
-    }
+    [JsonPropertyName("isni")]
+    public string? Isni { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitPublishedIn.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitPublishedIn.cs
@@ -1,41 +1,29 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitPublishedIn
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("title")]
-    public string? Title { get; set; }
+    public class SURFSharekitPublishedIn
+    {
+        [JsonPropertyName("title")] public string? Title { get; set; }
 
-    [JsonPropertyName("publisherDocument")]
-    public string? PublisherDocument { get; set; }
+        [JsonPropertyName("publisherDocument")]
+        public string? PublisherDocument { get; set; }
 
-    [JsonPropertyName("placeOfPublication")]
-    public string? PlaceOfPublication { get; set; }
+        [JsonPropertyName("placeOfPublication")]
+        public string? PlaceOfPublication { get; set; }
 
-    [JsonPropertyName("year")]
-    public int? Year { get; set; }
+        [JsonPropertyName("year")] public int? Year { get; set; }
 
-    [JsonPropertyName("issue")]
-    public string? Issue { get; set; }
+        [JsonPropertyName("issue")] public string? Issue { get; set; }
 
-    [JsonPropertyName("edition")]
-    public string? Edition { get; set; }
+        [JsonPropertyName("edition")] public string? Edition { get; set; }
 
-    [JsonPropertyName("issn")]
-    public string? Issn { get; set; }
+        [JsonPropertyName("issn")] public string? Issn { get; set; }
 
-    [JsonPropertyName("isbn")]
-    public string? Isbn { get; set; }
+        [JsonPropertyName("isbn")] public string? Isbn { get; set; }
 
-    [JsonPropertyName("pageStart")]
-    public int? PageStart { get; set; }
+        [JsonPropertyName("pageStart")] public int? PageStart { get; set; }
 
-    [JsonPropertyName("pageEnd")]
-    public int? PageEnd { get; set; }
+        [JsonPropertyName("pageEnd")] public int? PageEnd { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitPublishedIn.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitPublishedIn.cs
@@ -1,29 +1,36 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitPublishedIn
 {
-    public class SURFSharekitPublishedIn
-    {
-        [JsonPropertyName("title")] public string? Title { get; set; }
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
 
-        [JsonPropertyName("publisherDocument")]
-        public string? PublisherDocument { get; set; }
+    [JsonPropertyName("publisherDocument")]
+    public string? PublisherDocument { get; set; }
 
-        [JsonPropertyName("placeOfPublication")]
-        public string? PlaceOfPublication { get; set; }
+    [JsonPropertyName("placeOfPublication")]
+    public string? PlaceOfPublication { get; set; }
 
-        [JsonPropertyName("year")] public int? Year { get; set; }
+    [JsonPropertyName("year")]
+    public int? Year { get; set; }
 
-        [JsonPropertyName("issue")] public string? Issue { get; set; }
+    [JsonPropertyName("issue")]
+    public string? Issue { get; set; }
 
-        [JsonPropertyName("edition")] public string? Edition { get; set; }
+    [JsonPropertyName("edition")]
+    public string? Edition { get; set; }
 
-        [JsonPropertyName("issn")] public string? Issn { get; set; }
+    [JsonPropertyName("issn")]
+    public string? Issn { get; set; }
 
-        [JsonPropertyName("isbn")] public string? Isbn { get; set; }
+    [JsonPropertyName("isbn")]
+    public string? Isbn { get; set; }
 
-        [JsonPropertyName("pageStart")] public int? PageStart { get; set; }
+    [JsonPropertyName("pageStart")]
+    public int? PageStart { get; set; }
 
-        [JsonPropertyName("pageEnd")] public int? PageEnd { get; set; }
-    }
+    [JsonPropertyName("pageEnd")]
+    public int? PageEnd { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
@@ -8,8 +8,8 @@ public class SURFSharekitRepoItem
     public SURFSharekitAttributes? Attributes { get; set; }
 
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string? Type { get; set; }
 
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string? Id { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
@@ -1,20 +1,13 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitRepoItem
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("attributes")]
-    public SURFSharekitAttributes? SURFSharekitAttributes { get; set; }
+    public class SURFSharekitRepoItem
+    {
+        [JsonPropertyName("attributes")] public SURFSharekitAttributes? Attributes { get; set; }
 
-    [JsonPropertyName("type")]
-    public string? Type { get; set; }
+        [JsonPropertyName("type")] public string Type { get; set; }
 
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
+        [JsonPropertyName("id")] public string Id { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItem.cs
@@ -1,13 +1,15 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitRepoItem
 {
-    public class SURFSharekitRepoItem
-    {
-        [JsonPropertyName("attributes")] public SURFSharekitAttributes? Attributes { get; set; }
+    [JsonPropertyName("attributes")]
+    public SURFSharekitAttributes? Attributes { get; set; }
 
-        [JsonPropertyName("type")] public string Type { get; set; }
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
 
-        [JsonPropertyName("id")] public string Id { get; set; }
-    }
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItemLinks.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItemLinks.cs
@@ -7,17 +7,13 @@ using System.Text.Json.Serialization;
 
 namespace SURFSharekit.Net.Models;
 
-public class SURFSharekitLinks
+public class SURFSharekitRepoItemLinks
 {
-    [JsonPropertyName("first")]
-    public string? First { get; set; }
+    [JsonPropertyName("first")] public string? First { get; set; }
 
-    [JsonPropertyName("self")]
-    public string? Self { get; set; }
+    [JsonPropertyName("self")] public string? Self { get; set; }
 
-    [JsonPropertyName("next")]
-    public string? Next { get; set; }
+    [JsonPropertyName("next")] public string? Next { get; set; }
 
-    [JsonPropertyName("last")]
-    public string? Last { get; set; }
+    [JsonPropertyName("last")] public string? Last { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItemLinks.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItemLinks.cs
@@ -9,11 +9,15 @@ namespace SURFSharekit.Net.Models;
 
 public class SURFSharekitRepoItemLinks
 {
-    [JsonPropertyName("first")] public string? First { get; set; }
+    [JsonPropertyName("first")]
+    public string? First { get; set; }
 
-    [JsonPropertyName("self")] public string? Self { get; set; }
+    [JsonPropertyName("self")]
+    public string? Self { get; set; }
 
-    [JsonPropertyName("next")] public string? Next { get; set; }
+    [JsonPropertyName("next")]
+    public string? Next { get; set; }
 
-    [JsonPropertyName("last")] public string? Last { get; set; }
+    [JsonPropertyName("last")]
+    public string? Last { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItemsResult.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItemsResult.cs
@@ -1,23 +1,17 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitRepoItemsResult
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("meta")]
-    public SURFSharekitMeta? SURFSharekitMeta { get; set; }
+    public class SURFSharekitRepoItemsResult
+    {
+        [JsonPropertyName("name")] public string? Name { get; set; }
 
-    [JsonPropertyName("filters")]
-    public List<string> Filters { get; set; } = [];
+        [JsonPropertyName("meta")] public SURFSharekitMeta? Meta { get; set; }
 
-    [JsonPropertyName("links")]
-    public SURFSharekitLinks? SURFSharekitLinks { get; set; }
+        [JsonPropertyName("filters")] public List<string> Filters { get; set; } = [];
 
-    [JsonPropertyName("data")]
-    public List<SURFSharekitRepoItem> Data { get; set; } = [];
+        [JsonPropertyName("links")] public SURFSharekitRepoItemLinks? Links { get; set; }
+
+        [JsonPropertyName("data")] public List<SURFSharekitRepoItem> Data { get; set; } = [];
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitRepoItemsResult.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitRepoItemsResult.cs
@@ -1,17 +1,21 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitRepoItemsResult
 {
-    public class SURFSharekitRepoItemsResult
-    {
-        [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 
-        [JsonPropertyName("meta")] public SURFSharekitMeta? Meta { get; set; }
+    [JsonPropertyName("meta")]
+    public SURFSharekitMeta? Meta { get; set; }
 
-        [JsonPropertyName("filters")] public List<string> Filters { get; set; } = [];
+    [JsonPropertyName("filters")]
+    public List<string> Filters { get; set; } = [];
 
-        [JsonPropertyName("links")] public SURFSharekitRepoItemLinks? Links { get; set; }
+    [JsonPropertyName("links")]
+    public SURFSharekitRepoItemLinks? Links { get; set; }
 
-        [JsonPropertyName("data")] public List<SURFSharekitRepoItem> Data { get; set; } = [];
-    }
+    [JsonPropertyName("data")]
+    public List<SURFSharekitRepoItem> Data { get; set; } = [];
 }

--- a/SURFSharekit.Net/Models/SURFSharekitTypicalAgeRange.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitTypicalAgeRange.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SURFSharekit.Net.Models
+{
+    public class SURFSharekitTypicalAgeRange
+    {
+        [JsonPropertyName("string")] public string? String { get; set; }
+    }
+}

--- a/SURFSharekit.Net/Models/SURFSharekitTypicalAgeRange.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitTypicalAgeRange.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitTypicalAgeRange
 {
-    public class SURFSharekitTypicalAgeRange
-    {
-        [JsonPropertyName("string")] public string? String { get; set; }
-    }
+    [JsonPropertyName("string")]
+    public string? String { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitVocabularies.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitVocabularies.cs
@@ -1,20 +1,21 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
+namespace SURFSharekit.Net.Models;
+
+public class SURFSharekitVocabularies
 {
-    public class SURFSharekitVocabularies
-    {
-        [JsonPropertyName("vocabularyZiezo")] public List<SURFSharekitVocabulary> VocabularyZiezo { get; set; } = [];
+    [JsonPropertyName("vocabularyZiezo")]
+    public List<SURFSharekitVocabulary> VocabularyZiezo { get; set; } = [];
 
-        [JsonPropertyName("vocabularyDas")] public List<SURFSharekitVocabulary> VocabularyDas { get; set; } = [];
+    [JsonPropertyName("vocabularyDas")]
+    public List<SURFSharekitVocabulary> VocabularyDas { get; set; } = [];
 
-        [JsonPropertyName("vocabularyInformationLiteracy")]
-        public List<SURFSharekitVocabulary> VocabularyInformationLiteracy { get; set; } = [];
+    [JsonPropertyName("vocabularyInformationLiteracy")]
+    public List<SURFSharekitVocabulary> VocabularyInformationLiteracy { get; set; } = [];
 
-        [JsonPropertyName("vocabularyVerpleegkunde")]
-        public List<SURFSharekitVocabulary> VocabularyVerpleegkunde { get; set; } = [];
+    [JsonPropertyName("vocabularyVerpleegkunde")]
+    public List<SURFSharekitVocabulary> VocabularyVerpleegkunde { get; set; } = [];
 
-        [JsonPropertyName("vocabularyVaktherapie")]
-        public List<SURFSharekitVocabulary> VocabularyVaktherapie { get; set; } = [];
-    }
+    [JsonPropertyName("vocabularyVaktherapie")]
+    public List<SURFSharekitVocabulary> VocabularyVaktherapie { get; set; } = [];
 }

--- a/SURFSharekit.Net/Models/SURFSharekitVocabularies.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitVocabularies.cs
@@ -1,26 +1,20 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitVocabularies
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("vocabularyZiezo")]
-    public List<SURFSharekitVocabulary> VocabularyZiezo { get; set; } = [];
+    public class SURFSharekitVocabularies
+    {
+        [JsonPropertyName("vocabularyZiezo")] public List<SURFSharekitVocabulary> VocabularyZiezo { get; set; } = [];
 
-    [JsonPropertyName("vocabularyDas")]
-    public List<SURFSharekitVocabulary> VocabularyDas { get; set; } = [];
+        [JsonPropertyName("vocabularyDas")] public List<SURFSharekitVocabulary> VocabularyDas { get; set; } = [];
 
-    [JsonPropertyName("vocabularyInformationLiteracy")]
-    public List<SURFSharekitVocabulary> VocabularyInformationLiteracy { get; set; } = [];
+        [JsonPropertyName("vocabularyInformationLiteracy")]
+        public List<SURFSharekitVocabulary> VocabularyInformationLiteracy { get; set; } = [];
 
-    [JsonPropertyName("vocabularyVerpleegkunde")]
-    public List<SURFSharekitVocabulary> VocabularyVerpleegkunde { get; set; } = [];
+        [JsonPropertyName("vocabularyVerpleegkunde")]
+        public List<SURFSharekitVocabulary> VocabularyVerpleegkunde { get; set; } = [];
 
-    [JsonPropertyName("vocabularyVaktherapie")]
-    public List<SURFSharekitVocabulary> VocabularyVaktherapie { get; set; } = [];
+        [JsonPropertyName("vocabularyVaktherapie")]
+        public List<SURFSharekitVocabulary> VocabularyVaktherapie { get; set; } = [];
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitVocabulary.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitVocabulary.cs
@@ -1,17 +1,11 @@
-// This program has been developed by students from the bachelor Computer Science at Utrecht
-// University within the Software Project course.
-// 
-// © Copyright Utrecht University (Department of Information and Computing Sciences)
-
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models;
-
-public class SURFSharekitVocabulary
+namespace SURFSharekit.Net.Models
 {
-    [JsonPropertyName("source")]
-    public string? Source { get; set; }
+    public class SURFSharekitVocabulary
+    {
+        [JsonPropertyName("source")] public string? Source { get; set; }
 
-    [JsonPropertyName("value")]
-    public string? Value { get; set; }
+        [JsonPropertyName("value")] public string? Value { get; set; }
+    }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitVocabulary.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitVocabulary.cs
@@ -1,11 +1,12 @@
 using System.Text.Json.Serialization;
 
-namespace SURFSharekit.Net.Models
-{
-    public class SURFSharekitVocabulary
-    {
-        [JsonPropertyName("source")] public string? Source { get; set; }
+namespace SURFSharekit.Net.Models;
 
-        [JsonPropertyName("value")] public string? Value { get; set; }
-    }
+public class SURFSharekitVocabulary
+{
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
 }

--- a/SURFSharekit.Net/Models/SURFSharekitWebhookPayload.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitWebhookPayload.cs
@@ -32,7 +32,7 @@ public class SURFSharekitWebhookPayload
     /// </summary>
     [JsonPropertyName("type")]
     public SURFSharekitWebhookPayloadType Type { get; set; }
-    
+
     /// <summary>
     /// Timestamp indicating the time at which the webhook was created.
     /// </summary>

--- a/SURFSharekit.Net/Models/SURFSharekitWebhookPayload.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitWebhookPayload.cs
@@ -31,8 +31,8 @@ public class SURFSharekitWebhookPayload
     /// Type of webhook, the following types are supported: "Create", "Update" and "Delete".
     /// </summary>
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
-
+    public SURFSharekitWebhookPayloadType Type { get; set; }
+    
     /// <summary>
     /// Timestamp indicating the time at which the webhook was created.
     /// </summary>

--- a/SURFSharekit.Net/Models/SURFSharekitWebhookPayloadType.cs
+++ b/SURFSharekit.Net/Models/SURFSharekitWebhookPayloadType.cs
@@ -1,0 +1,16 @@
+// This program has been developed by students from the bachelor Computer Science at Utrecht
+// University within the Software Project course.
+// 
+// © Copyright Utrecht University (Department of Information and Computing Sciences)
+
+using System.Text.Json.Serialization;
+
+namespace SURFSharekit.Net.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter<SURFSharekitWebhookPayloadType>))]
+public enum SURFSharekitWebhookPayloadType
+{
+    Create,
+    Update,
+    Delete,
+}


### PR DESCRIPTION
## YouTrack tasks

CX-227

## Description

Webhook 'Type' is now an Enum instead of string
## Side Effects

- Reformat wrapper, Jsonpropertyname are now on separate lines.
- All models have been replaced because the docs were not up to date. Now they're accurate to the API response.
## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
