### PR TITLE
fix: delete model now has list as attributes

### DIFF
--- a/SURFSharekit.Net.Tests/SURFSharekitApiClientTests.cs
+++ b/SURFSharekit.Net.Tests/SURFSharekitApiClientTests.cs
@@ -216,7 +216,7 @@ public class SURFSharekitApiClientTests
     /// Then it should throw an exception.
     /// </summary>
     [Fact]
-    public async Task GetRepoItemById_IsInvalidId_Throws()
+    public async Task GetRepoItemById_ShouldThrow_WhenIdIsInvalid()
     {
         // dummy json obtained from api specification
         const string json = """
@@ -247,7 +247,7 @@ public class SURFSharekitApiClientTests
     /// Then it should throw an exception.
     /// </summary>
     [Fact]
-    public async Task GetRepoItemById_NotAuthenticated_Throws()
+    public async Task GetRepoItemById_ShouldThrow_WhenNotAuthenticated()
     {
         // dummy json obtained from api specification
         const string json = "Incorrect token";
@@ -274,7 +274,7 @@ public class SURFSharekitApiClientTests
     /// Then it should return a list of <see cref="SURFSharekitRepoItem"/> objects.
     /// </summary>
     [Fact]
-    public async Task GetAllRepoItems_ReturnsListOfSURFSharekitRepoItems()
+    public async Task GetAllRepoItems_ShouldReturnListOfSURFSharekitRepoItems_WhenAuthenticated()
     {
         // Arrange: Prepare dummy JSON for a SURFSharekitRepoItemsResult.
         const string json = """

--- a/SURFSharekit.Net/Models/Webhooks/SURFSharekitWebhookDelete.cs
+++ b/SURFSharekit.Net/Models/Webhooks/SURFSharekitWebhookDelete.cs
@@ -8,8 +8,17 @@ using SURFSharekit.Net.Models.RepoItem;
 
 namespace SURFSharekit.Net.Models.Webhooks;
 
-public class SURFSharekitWebhookDelete : SURFSharekitRepoItem
+public class SURFSharekitWebhookDelete
 {
     [JsonPropertyName("meta")]
     public SURFSharekitWebhookDeleteMeta DeleteMeta { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public List<object> Attributes { get; set; } = [];
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
 }


### PR DESCRIPTION
## YouTrack tasks

CX-282
CX-284

## Description

Delete model now has a list as 'attributes', this was a SURFSharekitAttributes object, but in the delete model this becomes an empty list.

## Side Effects

Renames tests to better format

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
